### PR TITLE
Update 01-reference-androidqf-dictionary.md

### DIFF
--- a/docs/en/references/01-reference-androidqf-dictionary/01-reference-androidqf-dictionary.md
+++ b/docs/en/references/01-reference-androidqf-dictionary/01-reference-androidqf-dictionary.md
@@ -1,5 +1,5 @@
 ---
-title: AdroidQF output file dictionary
+title: AndroidQF output file dictionary
 summary: dictionary of androidqf resulting files 
 keywords: android, androidqf, reference
 authors: Daniel Bedoya Arroyo


### PR DESCRIPTION
Corrected a spelling mistake in the YAML frontmatter.
In the Title field AndroidQF was missing the 'n' and was written as "AdroidQF". 